### PR TITLE
Update install.md for broken link in install guide to goose download

### DIFF
--- a/installation/install.md
+++ b/installation/install.md
@@ -9,7 +9,7 @@ has_children: false
 
 # Download
 
-[Latest](release/current/goose){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 .text-grey-dk-300 }
+[Latest](/release/current/canada){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 .text-grey-dk-300 }
 
 {: .note }
 > Always ensure you download from our official download page or supported mirrors!


### PR DESCRIPTION
Similar fix to previous installation guide link, it was broken, this time I needed the / and changed goose to canada